### PR TITLE
Fix read so that it returns correct +/- values

### DIFF
--- a/Adafruit_MLX30393.cpp
+++ b/Adafruit_MLX30393.cpp
@@ -153,7 +153,7 @@ Adafruit_MLX90393::readData(float *x, float *y, float *z)
     uint8_t tx_mode[1] = { MLX90393_REG_SM | MLX90393_AXIS_ALL };
     uint8_t tx[1] = { MLX90393_REG_RM | MLX90393_AXIS_ALL };
     uint8_t rx[6] = { 0 };
-    uint16_t xi, yi, zi;
+    int16_t xi, yi, zi;
 
     /* Set the device to single measurement mode */
     ok = transceive(tx_mode, sizeof tx_mode, NULL, 0);


### PR DESCRIPTION
The values returned from the MLX90393 are signed 16 bit values assuming TCMP_EN=0, which
it is when used with this library. Simply changing the types of xi, yi and zi from uint16_t to int16_t
forces the appropriate conversions.

Under the previous version of the code, only non-negative values were returned. For gain 1x, the values returned for x/y values were 0-10,551. 