### PR TITLE
Fix scaling lookup table when HALLCONF == 0x00.

### DIFF
--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -28,6 +28,7 @@ Adafruit_MLX90393::Adafruit_MLX90393(TwoWire *wireBus) {
   _transport = MLX90393_TRANSPORT_I2C;
   _initialized = false;
   _gain = MLX90393_GAIN_1X;
+  _hall_conf = MLX90393_HALL_CONF_2PHASE;
   _i2caddr = 0;
 }
 
@@ -67,15 +68,16 @@ bool Adafruit_MLX90393::begin(uint8_t i2caddr) {
  *
  * @return True if the operation succeeded, otherwise false.
  */
-bool Adafruit_MLX90393::setGain(enum mlx90393_gain gain) {
+bool Adafruit_MLX90393::setGain(enum mlx90393_gain gain, enum mlx90393_hall_conf hall_conf) {
   bool ok;
 
   _gain = gain;
+  _hall_conf = hall_conf;
 
   /* Set CONF1, including gain. */
   uint8_t tx[4] = {
       MLX90393_REG_WR, 0x00,
-      (uint8_t)(((_gain & 0x7) << MLX90393_GAIN_SHIFT) | MLX90393_HALL_CONF),
+      (uint8_t)(((_gain & 0x7) << MLX90393_GAIN_SHIFT) | _hall_conf),
       (MLX90393_CONF1 & 0x3F) << 2};
 
   /* Perform the transaction. */
@@ -160,6 +162,12 @@ bool Adafruit_MLX90393::readData(float *x, float *y, float *z) {
   *x = (float)xi * mlx90393_lsb_lookup[0][_gain][0][0];
   *y = (float)yi * mlx90393_lsb_lookup[0][_gain][0][0];
   *z = (float)zi * mlx90393_lsb_lookup[0][_gain][0][1];
+
+  if (_hall_conf == MLX90393_HALL_CONF_2PHASE) {
+    *x *= MLX90393_HALL_CONF_2PHASE_SCALING;
+    *y *= MLX90393_HALL_CONF_2PHASE_SCALING;
+    *z *= MLX90393_HALL_CONF_2PHASE_SCALING;
+  }
 
   return ok;
 }

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -68,7 +68,8 @@ bool Adafruit_MLX90393::begin(uint8_t i2caddr) {
  *
  * @return True if the operation succeeded, otherwise false.
  */
-bool Adafruit_MLX90393::setGain(enum mlx90393_gain gain, enum mlx90393_hall_conf hall_conf) {
+bool Adafruit_MLX90393::setGain(enum mlx90393_gain gain,
+                                enum mlx90393_hall_conf hall_conf) {
   bool ok;
 
   _gain = gain;

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -65,6 +65,7 @@ bool Adafruit_MLX90393::begin(uint8_t i2caddr) {
  * Sets the sensor gain to the specified level.
  *
  * @param gain  The gain level to set.
+ * @param hall_conf  Hall plate spinning rate adjustment.
  *
  * @return True if the operation succeeded, otherwise false.
  */

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -35,6 +35,8 @@
 #define MLX90393_STATUS_OK (0x00)   /**< OK value for status response. */
 #define MLX90393_STATUS_MASK (0xFC) /**< Mask for status OK checks. */
 
+#define MLX90393_HALL_CONF_2PHASE_SCALING     98.0/75.0
+
 /** Register map. */
 enum {
   MLX90393_REG_SB = (0x10),  /**< Start burst mode. */
@@ -68,11 +70,17 @@ enum mlx90393_transport {
   MLX90393_TRANSPORT_SPI
 };
 
-/** Lookup table to convert raw values to uT based on [HALLCONF][GAIN_SEL][RES].
+/** Hall plate configuration. */
+enum mlx90393_hall_conf {
+  MLX90393_HALL_CONF_2PHASE = (0x00),
+  MLX90393_HALL_CONF_4PHASE = (0x0C)
+};
+
+/** Lookup table to convert raw values to uT based on [TEMP][GAIN_SEL][RES].
  */
 const float mlx90393_lsb_lookup[2][8][4][2] = {
 
-    /* HALLCONF = 0xC (default) */
+    /* HALLCONF = 0xC (default), sensitivity in uT/LSB, TC off, T=25°C */
     {
         /* GAIN_SEL = 0, 5x gain */
         {{0.751, 1.210}, {1.502, 2.420}, {3.004, 4.840}, {6.009, 9.680}},
@@ -92,7 +100,7 @@ const float mlx90393_lsb_lookup[2][8][4][2] = {
         {{0.150, 0.242}, {0.300, 0.484}, {0.601, 0.968}, {1.202, 1.936}},
     },
 
-    /* HALLCONF = 0x0 */
+    /* HALLCONF = 0xC, sensitivity in uT/LSB, TC off, T=35°C  */
     {
         /* GAIN_SEL = 0, 5x gain */
         {{0.787, 1.267}, {1.573, 2.534}, {3.146, 5.068}, {6.292, 10.137}},
@@ -120,7 +128,7 @@ public:
   Adafruit_MLX90393(TwoWire *wireBus = &Wire);
 
   bool begin(uint8_t i2caddr = MLX90393_DEFAULT_ADDR);
-  bool setGain(enum mlx90393_gain gain);
+  bool setGain(enum mlx90393_gain gain, enum mlx90393_hall_conf hall_conf = MLX90393_HALL_CONF_4PHASE);
   bool setTrigInt(bool state);
   enum mlx90393_gain getGain(void);
   bool readData(float *x, float *y, float *z);
@@ -128,6 +136,7 @@ public:
 private:
   enum mlx90393_transport _transport;
   enum mlx90393_gain _gain;
+  enum mlx90393_hall_conf _hall_conf;
   TwoWire *_wire;
   bool _initialized;
   uint8_t _i2caddr;

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -35,7 +35,7 @@
 #define MLX90393_STATUS_OK (0x00)   /**< OK value for status response. */
 #define MLX90393_STATUS_MASK (0xFC) /**< Mask for status OK checks. */
 
-#define MLX90393_HALL_CONF_2PHASE_SCALING     98.0/75.0
+#define MLX90393_HALL_CONF_2PHASE_SCALING 98.0 / 75.0
 
 /** Register map. */
 enum {
@@ -128,7 +128,8 @@ public:
   Adafruit_MLX90393(TwoWire *wireBus = &Wire);
 
   bool begin(uint8_t i2caddr = MLX90393_DEFAULT_ADDR);
-  bool setGain(enum mlx90393_gain gain, enum mlx90393_hall_conf hall_conf = MLX90393_HALL_CONF_4PHASE);
+  bool setGain(enum mlx90393_gain gain,
+               enum mlx90393_hall_conf hall_conf = MLX90393_HALL_CONF_4PHASE);
   bool setTrigInt(bool state);
   enum mlx90393_gain getGain(void);
   bool readData(float *x, float *y, float *z);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MLX90393
-version=1.1.1
+version=1.1.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Driver for the MLX90393 magenetic field sensor


### PR DESCRIPTION
Change is not tested due to the absense of the hardware.
