### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -45,6 +45,8 @@ bool Adafruit_MLX90393::begin(uint8_t i2caddr) {
   case MLX90393_TRANSPORT_I2C:
     _wire->begin();
     _i2caddr = i2caddr;
+    i2c_dev = new Adafruit_I2CDevice(_i2caddr, _wire);
+    i2c_dev->begin();
     break;
   case MLX90393_TRANSPORT_SPI:
     /* Currently not handled due to HW layout. */
@@ -180,15 +182,12 @@ bool Adafruit_MLX90393::transceive(uint8_t *txbuf, uint8_t txlen,
                                    uint8_t *rxbuf, uint8_t rxlen) {
   uint8_t status = 0;
   uint8_t i;
+  uint8_t rxbuf2[rxlen+1];
 
   /* Write stage */
   switch (_transport) {
   case MLX90393_TRANSPORT_I2C:
-    _wire->beginTransmission(_i2caddr);
-    for (i = 0; i < txlen; i++) {
-      _wire->write(txbuf[i]);
-    }
-    _wire->endTransmission();
+    i2c_dev->write(txbuf, txlen);
     /* Wait a bit befoore requesting a response. */
     delay(10);
     break;
@@ -200,15 +199,10 @@ bool Adafruit_MLX90393::transceive(uint8_t *txbuf, uint8_t txlen,
   /* Read stage. */
   switch (_transport) {
   case MLX90393_TRANSPORT_I2C:
-    _wire->requestFrom(_i2caddr, (uint8_t)((rxlen + 1) & 0xFF));
-    /* Always request the status byte. */
-    status = _wire->read();
-    /* Read any other bytes that have been requested. */
-    if (rxbuf != NULL) {
-      for (i = 0; i < rxlen; i++) {
-        rxbuf[i] = _wire->read();
-      }
-    }
+    /* Read status byte plus any others */
+    i2c_dev->read(rxbuf2, rxlen+1);
+    status = rxbuf2[0];
+    for (i=0; i<rxlen; i++) rxbuf[i] = rxbuf2[i+1];
     break;
   case MLX90393_TRANSPORT_SPI:
     /* Currently not handled due to HW layout. */

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -182,7 +182,7 @@ bool Adafruit_MLX90393::transceive(uint8_t *txbuf, uint8_t txlen,
                                    uint8_t *rxbuf, uint8_t rxlen) {
   uint8_t status = 0;
   uint8_t i;
-  uint8_t rxbuf2[rxlen+1];
+  uint8_t rxbuf2[rxlen + 1];
 
   /* Write stage */
   switch (_transport) {
@@ -200,9 +200,10 @@ bool Adafruit_MLX90393::transceive(uint8_t *txbuf, uint8_t txlen,
   switch (_transport) {
   case MLX90393_TRANSPORT_I2C:
     /* Read status byte plus any others */
-    i2c_dev->read(rxbuf2, rxlen+1);
+    i2c_dev->read(rxbuf2, rxlen + 1);
     status = rxbuf2[0];
-    for (i=0; i<rxlen; i++) rxbuf[i] = rxbuf2[i+1];
+    for (i = 0; i < rxlen; i++)
+      rxbuf[i] = rxbuf2[i + 1];
     break;
   case MLX90393_TRANSPORT_SPI:
     /* Currently not handled due to HW layout. */

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -19,8 +19,8 @@
 #define ADAFRUIT_MLX90393_H
 
 #include "Arduino.h"
-#include <SPI.h>
 #include <Wire.h>
+#include <Adafruit_I2CDevice.h>
 
 #define MLX90393_DEFAULT_ADDR (0x0C) /* Can also be 0x18, depending on IC */
 
@@ -124,6 +124,9 @@ public:
   bool setTrigInt(bool state);
   enum mlx90393_gain getGain(void);
   bool readData(float *x, float *y, float *z);
+
+protected:
+  Adafruit_I2CDevice *i2c_dev;
 
 private:
   enum mlx90393_transport _transport;

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -19,8 +19,8 @@
 #define ADAFRUIT_MLX90393_H
 
 #include "Arduino.h"
-#include <Wire.h>
 #include <Adafruit_I2CDevice.h>
+#include <Wire.h>
 
 #define MLX90393_DEFAULT_ADDR (0x0C) /* Can also be 0x18, depending on IC */
 

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -126,7 +126,7 @@ public:
   bool readData(float *x, float *y, float *z);
 
 protected:
-  Adafruit_I2CDevice *i2c_dev;
+  Adafruit_I2CDevice *i2c_dev; /**< I2CDevice for bus management. */
 
 private:
   enum mlx90393_transport _transport;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MLX90393
-version=1.1.1
+version=1.1.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Driver for the MLX90393 magenetic field sensor
@@ -7,4 +7,4 @@ paragraph=Driver for the MLX90393 magenetic field sensor
 category=Sensors
 url=https://github.com/adafruit/Adafruit_MLX90393_Library
 architectures=*
-depends=Adafruit Unified Sensor
+depends=Adafruit BusIO, Adafruit Unified Sensor


### PR DESCRIPTION
For #6 

**[EDIT]** Also removes unused `SPI.h` import

Took a look at using register, but the MLX doesn't use direct access and instead has various "commands". So just kept it simple and using I2CDevice directly.

Tested with Itsy M0:

![mlx_test](https://user-images.githubusercontent.com/8755041/95638273-d60c8580-0a48-11eb-83c5-d0303c1cc970.jpg)

![Screenshot from 2020-10-09 15-54-54](https://user-images.githubusercontent.com/8755041/95638282-dc9afd00-0a48-11eb-9f1c-ba321f5b0c0a.png)

