### PR TITLE
Added support for constant offset correction

### DIFF
--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -132,6 +132,28 @@ bool Adafruit_MLX90393::reset(void) {
 }
 
 /**
+ * Store the non-volitile memory
+ * @return True if the operation succeeded, otherwise false.
+ */
+bool Adafruit_MLX90393::memoryStore(void) {
+  uint8_t tx[1] = {MLX90393_REG_HS};
+
+  /* Perform the transaction. */
+  return (transceive(tx, sizeof(tx), NULL, 0, 0) == MLX90393_STATUS_OK);
+}
+
+/**
+ * Recall the non-volitile memory
+ * @return True if the operation succeeded, otherwise false.
+ */
+bool Adafruit_MLX90393::memoryRecall(void) {
+  uint8_t tx[1] = {MLX90393_REG_HR};
+
+  /* Perform the transaction. */
+  return (transceive(tx, sizeof(tx), NULL, 0, 0) == MLX90393_STATUS_OK);
+}
+
+/**
  * Sets the sensor gain to the specified level.
  * @param gain  The gain level to set.
  * @return True if the operation succeeded, otherwise false.
@@ -264,6 +286,57 @@ bool Adafruit_MLX90393::setOversampling(
  */
 enum mlx90393_oversampling Adafruit_MLX90393::getOversampling(void) {
   return _osr;
+}
+
+/**
+ * Sets the axis constant offet correction to the specified offset.
+ * @param axis  The axis to set.
+ * @param offset  The offset.
+ * @return True if the operation succeeded, otherwise false.
+ */
+bool Adafruit_MLX90393::setOffset(enum mlx90393_axis axis, uint16_t offset) {
+  uint8_t reg;
+
+  switch (axis) {
+    case MLX90393_X: 
+      reg = MLX90393_CONF5;
+      break;
+    case MLX90393_Y: 
+      reg = MLX90393_CONF6;
+      break;
+    case MLX90393_Z: 
+      reg = MLX90393_CONF7;
+      break;
+  }
+
+  return writeRegister(reg, offset);
+}
+
+/**
+ * Gets the offset of the axis constant offet correction.
+ * This reads the offset from the sensors memory, 
+ * as it can be helpful to persist these offsets across power cycles.
+ * @param axis  The axis to get.
+ * @return The offset.
+ */
+uint16_t Adafruit_MLX90393::getOffset(enum mlx90393_axis axis) {
+  uint8_t reg = 0;
+  uint16_t data;
+
+  switch (axis) {
+    case MLX90393_X: 
+      reg = MLX90393_CONF5;
+      break;
+    case MLX90393_Y: 
+      reg = MLX90393_CONF6;
+      break;
+    case MLX90393_Z: 
+      reg = MLX90393_CONF7;
+      break;
+  }
+
+  readRegister(reg, &data);
+  return data;
 }
 
 /**

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -30,6 +30,9 @@
 #define MLX90393_CONF2 (0x01)         /**< Burst, comm mode */
 #define MLX90393_CONF3 (0x02)         /**< Oversampling, filter, res. */
 #define MLX90393_CONF4 (0x03)         /**< Sensitivty drift. */
+#define MLX90393_CONF5 (0x04)         /**< X-axis constant offset correction. */
+#define MLX90393_CONF6 (0x05)         /**< Y-axis constant offset correction. */
+#define MLX90393_CONF7 (0x06)         /**< Z-axis constant offset correction. */
 #define MLX90393_GAIN_SHIFT (4)       /**< Left-shift for gain bits. */
 #define MLX90393_HALL_CONF (0x0C)     /**< Hall plate spinning rate adj. */
 #define MLX90393_STATUS_OK (0x00)     /**< OK value for status response. */
@@ -48,7 +51,7 @@ enum {
   MLX90393_REG_WR = (0x60),  /**< Write register. */
   MLX90393_REG_EX = (0x80),  /**> Exit moode. */
   MLX90393_REG_HR = (0xD0),  /**< Memory recall. */
-  MLX90393_REG_HS = (0x70),  /**< Memory store. */
+  MLX90393_REG_HS = (0xE0),  /**< Memory store. */
   MLX90393_REG_RT = (0xF0),  /**< Reset. */
   MLX90393_REG_NOP = (0x00), /**< NOP. */
 };
@@ -178,6 +181,9 @@ public:
   bool reset(void);
   bool exitMode(void);
 
+  bool memoryStore();
+  bool memoryRecall();
+
   bool readMeasurement(float *x, float *y, float *z);
   bool startSingleMeasurement(void);
 
@@ -192,6 +198,9 @@ public:
 
   bool setOversampling(enum mlx90393_oversampling oversampling);
   enum mlx90393_oversampling getOversampling(void);
+
+  bool setOffset(enum mlx90393_axis, uint16_t offset);
+  uint16_t getOffset(enum mlx90393_axis);
 
   bool setTrigInt(bool state);
   bool readData(float *x, float *y, float *z);


### PR DESCRIPTION
In this PR, I've added support for setting and getting the offsets for the sensor's constant offet correction feature. 

New functions:
- `bool setOffset(enum mlx90393_axis, uint16_t offset)`
- `uint16_t getOffset(enum mlx90393_axis)`

As well as the following supporting functions to save these offsets (and other configuration) to non-volatile storage:
- `bool memoryStore()`
- `bool memoryRecall()`

Thanks for taking a look!