### PR TITLE
Performance fixes for the Adafruit_MLX90393 library

### DIFF
--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -316,9 +316,9 @@ bool Adafruit_MLX90393::startSingleMeasurement(uint8_t axes) {
  * @return True on command success
  */
 bool Adafruit_MLX90393::readMeasurement(float *x, float *y, float *z) {
-  const uint8_t flags = (x == nullptr ? 0 : MLX90393_AXIS_X)
-                      | (y == nullptr ? 0 : MLX90393_AXIS_Y)
-                      | (z == nullptr ? 0 : MLX90393_AXIS_Z);
+  const uint8_t flags = (x == nullptr ? 0 : MLX90393_AXIS_X) |
+                        (y == nullptr ? 0 : MLX90393_AXIS_Y) |
+                        (z == nullptr ? 0 : MLX90393_AXIS_Z);
 
   uint8_t tx[1] = {uint8_t(MLX90393_REG_RM | flags)};
   uint8_t rx[6] = {0};
@@ -364,32 +364,33 @@ bool Adafruit_MLX90393::readMeasurement(float *x, float *y, float *z) {
 /**
  * Performs a single X/Y/Z conversion and returns the results.
  *
- * @param x                           Pointer to where the 'x' value should be stored.
- * @param y                           Pointer to where the 'y' value should be stored.
- * @param z                           Pointer to where the 'z' value should be stored.
- * @param read_mode                   Library mode to read the sensor with. The device
- *                                    will always be configured with single measurement,
- *                                    but the user can select how they want to consume
- *                                    those measurements.
- * @param read_delay_mode             There is a delay to read the measurement. Should
- *                                    the user supply it, or should we calculate it?
- * @param maximum_read_delay_ms       If the user is supplying the read delay, they must
- *                                    specify it here. In MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
- *                                    the driver will wait for this time before trying to
- *                                    read the device. In MLX90393_READ_MODE_PRIORITIZE_PERFORMANCE,
- *                                    the driver will poll the device for at most this
- *                                    long before timing out. Note that if 0 is specified,
- *                                    it will just time out immediately, not wait forever.
- * 
+ * @param x                           Pointer to where the 'x' value should be
+ * stored.
+ * @param y                           Pointer to where the 'y' value should be
+ * stored.
+ * @param z                           Pointer to where the 'z' value should be
+ * stored.
+ * @param read_mode                   Library mode to read the sensor with. The
+ * device will always be configured with single measurement, but the user can
+ * select how they want to consume those measurements.
+ * @param read_delay_mode             There is a delay to read the measurement.
+ * Should the user supply it, or should we calculate it?
+ * @param maximum_read_delay_ms       If the user is supplying the read delay,
+ * they must specify it here. In MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC, the
+ * driver will wait for this time before trying to read the device. In
+ * MLX90393_READ_MODE_PRIORITIZE_PERFORMANCE, the driver will poll the device
+ * for at most this long before timing out. Note that if 0 is specified, it will
+ * just time out immediately, not wait forever.
+ *
  * @return True if the operation succeeded, otherwise false.
  */
 bool Adafruit_MLX90393::readData(float *x, float *y, float *z,
                                  enum mlx90393_read_mode read_mode,
                                  enum mlx90393_read_delay_mode read_delay_mode,
                                  unsigned long maximum_read_delay_ms) {
-  const uint8_t flags = (x == nullptr ? 0 : MLX90393_AXIS_X)
-                      | (y == nullptr ? 0 : MLX90393_AXIS_Y)
-                      | (z == nullptr ? 0 : MLX90393_AXIS_Z);
+  const uint8_t flags = (x == nullptr ? 0 : MLX90393_AXIS_X) |
+                        (y == nullptr ? 0 : MLX90393_AXIS_Y) |
+                        (z == nullptr ? 0 : MLX90393_AXIS_Z);
 
   if (!startSingleMeasurement(flags)) {
     return false;

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -293,6 +293,8 @@ bool Adafruit_MLX90393::setTrigInt(bool state) {
 /**
  * Begin a single measurement on all axes
  *
+ * @param axes  Which axes to measure.
+ *
  * @return True on command success
  */
 bool Adafruit_MLX90393::startSingleMeasurement(uint8_t axes) {

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -320,7 +320,7 @@ bool Adafruit_MLX90393::readMeasurement(float *x, float *y, float *z) {
                       | (y == nullptr ? 0 : MLX90393_AXIS_Y)
                       | (z == nullptr ? 0 : MLX90393_AXIS_Z);
 
-  uint8_t tx[1] = {MLX90393_REG_RM | flags};
+  uint8_t tx[1] = {(uint8_t)MLX90393_REG_RM | flags};
   uint8_t rx[6] = {0};
 
   /* Read a single data sample. */

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -16,6 +16,7 @@
   MIT license, all text above must be included in any redistribution
  *****************************************************************************/
 #include "Adafruit_MLX90393.h"
+#include <climits>
 
 /**
  * Instantiates a new Adafruit_MLX90393 class instance
@@ -295,7 +296,6 @@ bool Adafruit_MLX90393::setTrigInt(bool state) {
  * @return True on command success
  */
 bool Adafruit_MLX90393::startSingleMeasurement(uint8_t axes) {
-  assert((axes & ~MLX90393_AXIS_ALL) == 0);
   uint8_t tx[1] = {MLX90393_REG_SM | axes};
 
   /* Set the device to single measurement mode */
@@ -417,7 +417,7 @@ bool Adafruit_MLX90393::readData(float *x, float *y, float *z,
         elapsed_time = result_time - start_time;
       } else {
         // overflow
-        elapsed_time = (std::numeric_limits<unsigned long>::max() - start_time) + result_time;
+        elapsed_time = (ULONG_MAX - start_time) + result_time;
       }
     }
     status = done;

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -296,7 +296,7 @@ bool Adafruit_MLX90393::setTrigInt(bool state) {
  * @return True on command success
  */
 bool Adafruit_MLX90393::startSingleMeasurement(uint8_t axes) {
-  uint8_t tx[1] = {(uint8_t)MLX90393_REG_SM | axes};
+  uint8_t tx[1] = {uint8_t(MLX90393_REG_SM | axes)};
 
   /* Set the device to single measurement mode */
   uint8_t stat = transceive(tx, sizeof(tx), NULL, 0, 0);
@@ -320,7 +320,7 @@ bool Adafruit_MLX90393::readMeasurement(float *x, float *y, float *z) {
                       | (y == nullptr ? 0 : MLX90393_AXIS_Y)
                       | (z == nullptr ? 0 : MLX90393_AXIS_Z);
 
-  uint8_t tx[1] = {(uint8_t)MLX90393_REG_RM | flags};
+  uint8_t tx[1] = {uint8_t(MLX90393_REG_RM | flags)};
   uint8_t rx[6] = {0};
 
   /* Read a single data sample. */

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -16,7 +16,7 @@
   MIT license, all text above must be included in any redistribution
  *****************************************************************************/
 #include "Adafruit_MLX90393.h"
-#include <climits>
+#include <limits.h>
 
 /**
  * Instantiates a new Adafruit_MLX90393 class instance

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -371,7 +371,7 @@ bool Adafruit_MLX90393::readMeasurement(float *x, float *y, float *z) {
  *                                    will always be configured with single measurement,
  *                                    but the user can select how they want to consume
  *                                    those measurements.
- * @param mlx90393_read_delay_mode    There is a delay to read the measurement. Should
+ * @param read_delay_mode             There is a delay to read the measurement. Should
  *                                    the user supply it, or should we calculate it?
  * @param maximum_read_delay_ms       If the user is supplying the read delay, they must
  *                                    specify it here. In MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
@@ -385,7 +385,7 @@ bool Adafruit_MLX90393::readMeasurement(float *x, float *y, float *z) {
  */
 bool Adafruit_MLX90393::readData(float *x, float *y, float *z,
                                  enum mlx90393_read_mode read_mode,
-                                 enum mlx90393_read_delay_mode mlx90393_read_delay_mode,
+                                 enum mlx90393_read_delay_mode read_delay_mode,
                                  unsigned long maximum_read_delay_ms) {
   const uint8_t flags = (x == nullptr ? 0 : MLX90393_AXIS_X)
                       | (y == nullptr ? 0 : MLX90393_AXIS_Y)
@@ -396,7 +396,7 @@ bool Adafruit_MLX90393::readData(float *x, float *y, float *z,
   }
 
   float maximum_query_time_ms = maximum_read_delay_ms;
-  if (mlx90393_read_delay_mode == MLX90393_READ_DELAY_MODE_CALCULATE) {
+  if (read_delay_mode == MLX90393_READ_DELAY_MODE_CALCULATE) {
     // See MLX90393 Getting Started Guide for fancy formula
     // tconv = f(OSR, DIG_FILT, OSR2, ZYXT)
     // For now, using Table 18 from datasheet

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -296,7 +296,7 @@ bool Adafruit_MLX90393::setTrigInt(bool state) {
  * @return True on command success
  */
 bool Adafruit_MLX90393::startSingleMeasurement(uint8_t axes) {
-  uint8_t tx[1] = {MLX90393_REG_SM | axes};
+  uint8_t tx[1] = {(uint8_t)MLX90393_REG_SM | axes};
 
   /* Set the device to single measurement mode */
   uint8_t stat = transceive(tx, sizeof(tx), NULL, 0, 0);
@@ -316,9 +316,9 @@ bool Adafruit_MLX90393::startSingleMeasurement(uint8_t axes) {
  * @return True on command success
  */
 bool Adafruit_MLX90393::readMeasurement(float *x, float *y, float *z) {
-  uint8_t flags = (x == nullptr ? 0 : MLX90393_AXIS_X);
-  flags |= (y == nullptr ? 0 : MLX90393_AXIS_Y);
-  flags |= (z == nullptr ? 0 : MLX90393_AXIS_Z);
+  const uint8_t flags = (x == nullptr ? 0 : MLX90393_AXIS_X)
+                      | (y == nullptr ? 0 : MLX90393_AXIS_Y)
+                      | (z == nullptr ? 0 : MLX90393_AXIS_Z);
 
   uint8_t tx[1] = {MLX90393_REG_RM | flags};
   uint8_t rx[6] = {0};

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -384,8 +384,8 @@ bool Adafruit_MLX90393::readMeasurement(float *x, float *y, float *z) {
  * @return True if the operation succeeded, otherwise false.
  */
 bool Adafruit_MLX90393::readData(float *x, float *y, float *z,
-                                 mlx90393_read_mode read_mode,
-                                 mlx90393_read_delay_mode mlx90393_read_delay_mode,
+                                 enum mlx90393_read_mode read_mode,
+                                 enum mlx90393_read_delay_mode mlx90393_read_delay_mode,
                                  unsigned long maximum_read_delay_ms) {
   const uint8_t flags = (x == nullptr ? 0 : MLX90393_AXIS_X)
                       | (y == nullptr ? 0 : MLX90393_AXIS_Y)

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -103,6 +103,16 @@ typedef enum mlx90393_oversampling {
   MLX90393_OSR_3,
 } mlx90393_oversampling_t;
 
+typedef enum mlx90393_read_mode {
+  MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
+  MLX90393_READ_MODE_PRIORITIZE_PERFORMANCE,
+} mlx90393_read_mode;
+
+typedef enum mlx90393_read_delay_mode {
+  MLX90393_READ_DELAY_MODE_CALCULATE,
+  MLX90393_READ_DELAY_MODE_SUPPLY,
+} mlx90393_read_delay_mode;
+
 /** Lookup table to convert raw values to uT based on [HALLCONF][GAIN_SEL][RES].
  */
 const float mlx90393_lsb_lookup[2][8][4][2] = {
@@ -197,7 +207,10 @@ public:
   enum mlx90393_oversampling getOversampling(void);
 
   bool setTrigInt(bool state);
-  bool readData(float *x, float *y, float *z);
+  bool readData(float *x, float *y, float *z,
+                mlx90393_read_mode read_mode = MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
+                mlx90393_read_delay_mode = MLX90393_READ_DELAY_MODE_CALCULATE,
+                unsigned long maximum_read_delay_ms = 20);
 
   bool getEvent(sensors_event_t *event);
   void getSensor(sensor_t *sensor);

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -209,7 +209,7 @@ public:
   bool setTrigInt(bool state);
   bool readData(float *x, float *y, float *z,
                 enum mlx90393_read_mode read_mode = MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
-                enum mlx90393_read_delay_mode = MLX90393_READ_DELAY_MODE_CALCULATE,
+                enum mlx90393_read_delay_mode read_delay_mode = MLX90393_READ_DELAY_MODE_CALCULATE,
                 unsigned long maximum_read_delay_ms = 20);
 
   bool getEvent(sensors_event_t *event);

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -208,8 +208,8 @@ public:
 
   bool setTrigInt(bool state);
   bool readData(float *x, float *y, float *z,
-                mlx90393_read_mode read_mode = MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
-                mlx90393_read_delay_mode = MLX90393_READ_DELAY_MODE_CALCULATE,
+                enum mlx90393_read_mode read_mode = MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
+                enum mlx90393_read_delay_mode = MLX90393_READ_DELAY_MODE_CALCULATE,
                 unsigned long maximum_read_delay_ms = 20);
 
   bool getEvent(sensors_event_t *event);

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -106,12 +106,12 @@ typedef enum mlx90393_oversampling {
 typedef enum mlx90393_read_mode {
   MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
   MLX90393_READ_MODE_PRIORITIZE_PERFORMANCE,
-} mlx90393_read_mode;
+} mlx90393_read_mode_t;
 
 typedef enum mlx90393_read_delay_mode {
   MLX90393_READ_DELAY_MODE_CALCULATE,
   MLX90393_READ_DELAY_MODE_SUPPLY,
-} mlx90393_read_delay_mode;
+} mlx90393_read_delay_mode_t;
 
 /** Lookup table to convert raw values to uT based on [HALLCONF][GAIN_SEL][RES].
  */

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -25,6 +25,9 @@
 
 #define MLX90393_DEFAULT_ADDR (0x0C) /* Can also be 0x18, depending on IC */
 
+#define MLX90393_AXIS_X (0x02)        /**< X axis bit for commands. */
+#define MLX90393_AXIS_Y (0x04)        /**< Y axis bit for commands. */
+#define MLX90393_AXIS_Z (0x08)        /**< Z axis bit for commands. */
 #define MLX90393_AXIS_ALL (0x0E)      /**< X+Y+Z axis bits for commands. */
 #define MLX90393_CONF1 (0x00)         /**< Gain */
 #define MLX90393_CONF2 (0x01)         /**< Burst, comm mode */
@@ -179,7 +182,7 @@ public:
   bool exitMode(void);
 
   bool readMeasurement(float *x, float *y, float *z);
-  bool startSingleMeasurement(void);
+  bool startSingleMeasurement(uint8_t axes = MLX90393_AXIS_ALL);
 
   bool setGain(enum mlx90393_gain gain);
   enum mlx90393_gain getGain(void);

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -208,8 +208,10 @@ public:
 
   bool setTrigInt(bool state);
   bool readData(float *x, float *y, float *z,
-                enum mlx90393_read_mode read_mode = MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
-                enum mlx90393_read_delay_mode read_delay_mode = MLX90393_READ_DELAY_MODE_CALCULATE,
+                enum mlx90393_read_mode read_mode =
+                    MLX90393_READ_MODE_PRIORITIZE_BUS_TRAFFIC,
+                enum mlx90393_read_delay_mode read_delay_mode =
+                    MLX90393_READ_DELAY_MODE_CALCULATE,
                 unsigned long maximum_read_delay_ms = 20);
 
   bool getEvent(sensors_event_t *event);


### PR DESCRIPTION
**Overview:**
This change makes some small modifications to the MLX90393 library to enable it to achieve the 500Hz performance that the part claims in its spec sheet. In order to do this, there are two changes:
1. First, we modify readData (and friends) to be able to read arbitrary magnetometer axes, not just all axes. This can have a meaningful impact on conversion time, especially in adverse temperature conditions. In many use cases (for example, known mounting, or after a calibration period), a single axis magnetometer adds value (e.g. in rotary sensors, this is often sufficient).
2. More impactfully, we modify the readData function to change how it retrieves data from the sensor. As previously implemented, the library waits for the result to become available from the sensor using the table from the spec sheet plus a 10ms offset. That 10ms offset limits the performance of the library to 100Hz at maximum, and indeed in my testing (which admittedly has some business logic in between my timing code), I only achieve 88Hz (this is consistent with other issue reports claiming 90Hz performance). Instead, here we permit the user to choose if they want to prioritize traffic on the I2C bus (e.g. the existing implementation, with a single request that is likely to succeed) or performance (polling the device as fast as possible to get the result). In both cases we add the ability for the user to configure the timeout in readData.

All previous behavior is preserved and left as the default behavior of the library, so no existing clients should be affected when they take this library update.

**Testing & Results:**
I have tested all configurations of parameters locally on my ESP32, and achieve 400Hz performance for XYZ readings, and 500Hz performance when reading a single axis of the magnetometer. Without this change, I can only achieve 88Hz. I am not stupendously experienced with GitHub, so unfortunately I cannot work out how to run the CI without a commit, so sorry about that.

**Limitations:**
It would be better to not spam the bus with these requests, and instead wait for an interrupt. Unfortunately, as far as I can tell from the documentation, the DRDY flag is set with the INT pin, which is not guaranteed to be connected. This pin is not available in any of the readable configuration registers, and rewriting this library to be interrupt driven is out of scope.

Separately, it would be more efficient to use burst mode, as this would not ask the chip to constantly switch power states (e.g to standby and back to active). That said, the switching time is a handful of microseconds, so this does not majorly impact achievable frame rate. Again, this would be a major change to the library in excess of what is being done here.

**Future Work:**
The performance could be pushed further by reconfiguring the hall plate spin to 0x0, but the spec sheet is relatively sparse on details for use of this mode, which is clearly for expert users. If needed, a future pull request (perhaps by a more expert user than I) should be able to push this sensor to more than 700Hz in that mode. Similarly, as indicated above, perhaps a future contributor can implement burst mode.