### PR TITLE
ReadData method delay bug correction, the 10ms were removed since they were just needed because of delay function limitations.

### DIFF
--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -365,12 +365,12 @@ bool Adafruit_MLX90393::readData(float *x, float *y, float *z) {
   // See MLX90393 Getting Started Guide for fancy formula
   // tconv = f(OSR, DIG_FILT, OSR2, ZYXT)
   // For now, using Table 18 from datasheet
-  
+
   //obtain delay
   long delayMicros = mlx90393_tconv[_dig_filt][_osr] * 1000;
-  
-  //since delayMicrosenconds have a limit of 16383,
-  //divide delay into multiple parts
+
+  // Since delayMicrosenconds have a limit of 16383,
+  // Divide delay into multiple parts
   do {
     if (delayMicros >= 16383) {
       delayMicroseconds(16383);
@@ -384,7 +384,7 @@ bool Adafruit_MLX90393::readData(float *x, float *y, float *z) {
       delayMicros = 0;
     }
   } while (delayMicros > 0);
-  
+
   return readMeasurement(x, y, z);
 }
 

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -386,6 +386,15 @@ bool Adafruit_MLX90393::readData(float *x, float *y, float *z) {
   return readMeasurement(x, y, z);
 }
 
+/**
+ * Returns the delay in ms for the single read at the current configurations
+ *
+ * @return True if the operation succeeded, otherwise false.
+ */
+float Adafruit_MLX90393::getDelayForSingleMeasurment(void) {
+  return mlx90393_tconv[_dig_filt][_osr];
+}
+
 bool Adafruit_MLX90393::writeRegister(uint8_t reg, uint16_t data) {
   uint8_t tx[4] = {
       MLX90393_REG_WR,

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -365,8 +365,24 @@ bool Adafruit_MLX90393::readData(float *x, float *y, float *z) {
   // See MLX90393 Getting Started Guide for fancy formula
   // tconv = f(OSR, DIG_FILT, OSR2, ZYXT)
   // For now, using Table 18 from datasheet
-  // Without +10ms delay measurement doesn't always seem to work
-  delay(mlx90393_tconv[_dig_filt][_osr] + 10);
+  
+  //obtain delay
+  long delayMicros = mlx90393_tconv[_dig_filt][_osr] * 1000;
+  
+  //since delayMicrosenconds have a limit of 16383,
+  //divide delay into multiple parts
+  do {
+	if(delayMicros >= 16383) {
+		delayMicroseconds(16383);
+		delayMicros -= 16383;
+	}else {
+		//minimum delay for delayMicroseconds is 3 micro seconds
+		if(delayMicros < 3) delayMicros = 3;
+		delayMicroseconds(delayMicros);
+		delayMicros = 0;
+	}
+  } while(delayMicros > 0);
+  
   return readMeasurement(x, y, z);
 }
 

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -366,7 +366,7 @@ bool Adafruit_MLX90393::readData(float *x, float *y, float *z) {
   // tconv = f(OSR, DIG_FILT, OSR2, ZYXT)
   // For now, using Table 18 from datasheet
 
-  //obtain delay
+  // Obtain delay for current configuration
   long delayMicros = mlx90393_tconv[_dig_filt][_osr] * 1000;
 
   // Since delayMicrosenconds have a limit of 16383,

--- a/Adafruit_MLX90393.cpp
+++ b/Adafruit_MLX90393.cpp
@@ -372,16 +372,18 @@ bool Adafruit_MLX90393::readData(float *x, float *y, float *z) {
   //since delayMicrosenconds have a limit of 16383,
   //divide delay into multiple parts
   do {
-	if(delayMicros >= 16383) {
-		delayMicroseconds(16383);
-		delayMicros -= 16383;
-	}else {
-		//minimum delay for delayMicroseconds is 3 micro seconds
-		if(delayMicros < 3) delayMicros = 3;
-		delayMicroseconds(delayMicros);
-		delayMicros = 0;
-	}
-  } while(delayMicros > 0);
+    if (delayMicros >= 16383) {
+      delayMicroseconds(16383);
+      delayMicros -= 16383;
+    } else {
+      // minimum delay for delayMicroseconds is 3 micro seconds
+      if (delayMicros < 3) {
+        delayMicros = 3;
+      }
+      delayMicroseconds(delayMicros);
+      delayMicros = 0;
+    }
+  } while (delayMicros > 0);
   
   return readMeasurement(x, y, z);
 }

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -145,7 +145,8 @@ const float mlx90393_lsb_lookup[2][8][4][2] = {
     }};
 
 /** Lookup table for conversion time based on [DIF_FILT][OSR].
- */
+*	added 1ms to 7/3 since it would not work any other way, original value 200.37
+*/
 const float mlx90393_tconv[8][4] = {
     /* DIG_FILT = 0 */
     {1.27, 1.84, 3.00, 5.30},
@@ -162,7 +163,7 @@ const float mlx90393_tconv[8][4] = {
     /* DIG_FILT = 6 */
     {13.36, 26.04, 51.38, 102.07},
     /* DIG_FILT = 7 */
-    {25.65, 50.61, 100.53, 200.37},
+    {25.65, 50.61, 100.53, 201.37},
 };
 
 /**

--- a/Adafruit_MLX90393.h
+++ b/Adafruit_MLX90393.h
@@ -145,8 +145,9 @@ const float mlx90393_lsb_lookup[2][8][4][2] = {
     }};
 
 /** Lookup table for conversion time based on [DIF_FILT][OSR].
-*	added 1ms to 7/3 since it would not work any other way, original value 200.37
-*/
+ *	Added 1ms to [7][3] since the sensor was not able to return data
+ *  with the original delay value 200.37
+ */
 const float mlx90393_tconv[8][4] = {
     /* DIG_FILT = 0 */
     {1.27, 1.84, 3.00, 5.30},
@@ -181,6 +182,7 @@ public:
 
   bool readMeasurement(float *x, float *y, float *z);
   bool startSingleMeasurement(void);
+  float getDelayForSingleMeasurment(void);
 
   bool setGain(enum mlx90393_gain gain);
   enum mlx90393_gain getGain(void);


### PR DESCRIPTION
This change makes some small modifications to the MLX90393 library to enable it to achieve a higher Hz performance that the part claims in its spec sheet. 

The only change was to the readData method, which was altered to use delayMicrosenconds instead of delay.
It seems delay was not able to handle the float vaues such as 1.28 and so on, since it is only ready to receive long.

Only needing this small change means that no change to the actual behavior of the class was needed, all methods work as they did with the addition of better poll rates.

The value of the table is obtained and multiplied by 1000 to convert from milliseconds to microseconds, converting float to long to be utilized in the delayMicroseconds function.

Although delayMicroseconds also has limitations, max 16383 and min 3 microseconds, these can be worked around by spliting the delay into multiple delayMicroseconds taking into consideration the max allowed.

After this change a test for each of the modes was done making sure all worked with this change, where it was detected that the mode [DIF_FILT][OSR] = [7],[3] was not working properly in which the value was just incremented in 1ms in the table which corrected the issue for that mode too.

The test for the Hz(Only poll rate was tested) were done in the folloing way, in the loop it was incremented per cycle the number of polls and in each run of the loop a request is done to the sensor, the values are not written to the console to not consume CPU time, only if there is an issue, the actual poll rate is printed each second to minimize time printing to console.

The 500Hz were not obtainable, although in the fastest speed [DIF_FILT][OSR] = [0],[0] it was possible to obtain 369Hz poll Rate.

Code below:

`long lastSecond = millis();
int pollRate = 0;
float x, y, z;

void loop(void) {
  if(millis() - lastSecond > 1000) {
    Serial.print("Poll Rate: ");
    Serial.print(pollRate);
    Serial.println("Hz");
    pollRate = 0;
    lastSecond = millis();
  }

  // get X Y and Z data at once
  if (sensor.readData(&x, &y, &z)) pollRate++;
  else Serial.println("Unable to read XYZ data from the sensor.");
}`

The following teste was done for the [DIF_FILT][OSR] = [0],[0]
![image](https://github.com/user-attachments/assets/3f9ce5db-eb66-4c42-a1f2-ba3ba6805a65)



